### PR TITLE
fix: коррекция стилей карточек и параметров сетки под макет

### DIFF
--- a/src/common.blocks/card.scss
+++ b/src/common.blocks/card.scss
@@ -1,5 +1,5 @@
-@use "variables" as *;
-@use "mixins";
+@use 'variables' as *;
+@use 'mixins';
 
 .card {
   @include mixins.flex(column);

--- a/src/common.blocks/card.scss
+++ b/src/common.blocks/card.scss
@@ -1,34 +1,31 @@
-@use 'variables' as *;
-@use 'mixins';
+@use "variables" as *;
+@use "mixins";
 
 .card {
   @include mixins.flex(column);
-  border: 0;
+  min-height: 100%; // Позволяет карточке тянуться по высоте ячейки ряда
   border-radius: $defaultBorderRadius;
   background-color: $primary;
   color: white;
   padding: $defaultPadding;
   align-items: flex-start;
 
-  &_full {
-    flex-direction: row;
-    background-color: transparent;
-    align-items: center;
-
-    .card__title {
-      flex-grow: 0;
-    }
-  }
-
+  &_full,
   &_compact {
     flex-direction: row;
     background-color: transparent;
     align-items: center;
-    border-radius: 0;
+  }
 
+  &_compact {
+    border-radius: 0;
     .card__title {
       flex-grow: 1;
     }
+  }
+
+  &_full .card__title {
+    flex-grow: 0;
   }
 
   &__column {
@@ -54,6 +51,7 @@
     font-weight: 500;
     margin: 0;
     flex-grow: 1;
+    max-width: 83%;
   }
   &__text {
     text-align: left;
@@ -84,5 +82,8 @@
   &__action {
   }
   &__price {
+    font-size: 30px;
+    line-height: 100%;
+    margin: 0;
   }
 }

--- a/src/common.blocks/gallery.scss
+++ b/src/common.blocks/gallery.scss
@@ -2,14 +2,13 @@
 @use "mixins";
 
 .gallery {
-  @include mixins.container;
-  @include mixins.grid(600px, 24px);
+  @include mixins.container(80px, 0, 160px, 0);
+  @include mixins.grid(648px, 24px);
 
   &__item {
-    border: none;
+    @include mixins.flex(column);
     border-radius: $defaultBorderRadius;
     @include mixins.selectable($secondary, 2px, $primaryLight);
-
     &::after {
       border-radius: 0.8rem;
     }

--- a/src/common.blocks/gallery.scss
+++ b/src/common.blocks/gallery.scss
@@ -1,5 +1,5 @@
-@use "variables" as *;
-@use "mixins";
+@use 'variables' as *;
+@use 'mixins';
 
 .gallery {
   @include mixins.container(80px, 0, 160px, 0);

--- a/src/common.blocks/header.scss
+++ b/src/common.blocks/header.scss
@@ -6,7 +6,7 @@
   background-color: $primary;
 
   &__container {
-    @include mixins.container(45px,45px);
+    @include mixins.container(45px, 0, 45px, 0);
     @include mixins.flex(row);
     align-items: center;
     justify-content: space-between;

--- a/src/common.blocks/header.scss
+++ b/src/common.blocks/header.scss
@@ -1,5 +1,5 @@
-@use "variables" as *;
-@use "mixins";
+@use 'variables' as *;
+@use 'mixins';
 
 .header {
   height: $headerHeight;

--- a/src/scss/mixins/_container.scss
+++ b/src/scss/mixins/_container.scss
@@ -1,11 +1,11 @@
 @use "variables" as *;
 
-@mixin container($top: $defaultPadding, $bottom: $defaultPadding) {
+@mixin container($top: $defaultPadding, $right: $defaultPadding, $bottom: $defaultPadding, $left: $defaultPadding) {
   margin: auto;
   width: 100%;
   box-sizing: border-box;
   max-width: $maxPageWidth;
-  padding: $top $defaultPadding $bottom;
+  padding: $top $right $bottom $left;
 }
 
 @mixin sublayer {
@@ -25,4 +25,5 @@
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax($min, 1fr));
   grid-gap: $gap;
+  grid-auto-rows: auto;
 }

--- a/src/scss/mixins/_container.scss
+++ b/src/scss/mixins/_container.scss
@@ -1,4 +1,4 @@
-@use "variables" as *;
+@use 'variables' as *;
 
 @mixin container($top: $defaultPadding, $right: $defaultPadding, $bottom: $defaultPadding, $left: $defaultPadding) {
   margin: auto;


### PR DESCRIPTION
- **Выравнивание высоты карточек:**
1) В .card добавлено свойство height: 100%. В сочетании с display: grid в родительской галерее это позволяет всем карточкам в одном ряду иметь одинаковую высоту, независимо от количества строк в заголовке.

- **Доработка миксина container:**
2) Обновлен миксин container в _container.scss. Теперь он поддерживает индивидуальные отступы для всех четырех сторон (top, right, bottom, left), что обеспечило более гибкую настройку секций.

> Техническое обоснование изменений в миксине container:
> Изначальная реализация миксина ограничивала возможность задания специфических вертикальных и горизонтальных отступов, что приводило к конфликтам при реализации PixelPerfect.
> Перевод миксина на четыре параметра (top, right, bottom, left) с сохранением дефолтных значений позволил избавиться от лишних переопределений padding в конечных файлах стилей и обеспечил точное соответствие макету для шапки и галереи без нарушения принципа DRY.
> 

- **Коррекция отступов и сетки:**
3) В gallery.scss уточнены внешние отступы контейнера и параметры грида (ширина колонки 648px и гэп 24px) согласно замерам в макете.
4) В header.scss обновлены внутренние отступы шапки до 45px.

- **Типографика:**
5) Скорректированы стили шрифта и line-height для цен в блоке card.scss.

- **Дополнительно:**
6) Были схлопнуты общие стили 
```scss
&_compact, &_full { }
```

Стоит учесть, что макет проектной работы, разработанный дизайнером был сделан не в лучшем образе. На мой взгляд дизайнер видимо не дружил с математикой, ибо отступы у картинок внутри карточек в зависимости от однострочного/многострочного заголовка реализовать действительно трудно. Надеюсь в дальнейшем макет шаблона проектной работы в FIgma будет подкорректирован.

